### PR TITLE
Fix typo in TODO comment in src/state.rs

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -52,7 +52,7 @@ pub struct State {
     // block_proposer: BlockProposer,
     // block_executor: BlockExecutor,
     // rpc_server: Option<RpcServerHandle>,
-    // TODO: replace this wiith rpc server
+    // TODO: replace this with rpc server
     pub transaction_pool: TransactionPool,
     pub current_height: Height,
     pub current_round: Round,


### PR DESCRIPTION
This PR fixes a typo in a TODO comment in the State struct definition:
- Changed "wiith rpc server" to "with rpc server"

This is a minor documentation fix with no functional changes.